### PR TITLE
Changes for supporting cookie authorization

### DIFF
--- a/examples/flask_app/.onv
+++ b/examples/flask_app/.onv
@@ -6,3 +6,4 @@
 #export JWT_OIDC_ISSUER="https://sso-dev.pathfinder.gov.bc.ca/auth/realms/sbc"
 #export JWT_OIDC_AUDIENCE="NameX-Dev"
 #export JWT_OIDC_CLIENT_SECRET="	 b05bae52-e0d3-4c42-9954-594b22d1d24b"
+#export JWT_OIDC_AUTH_COOKIE_NAME="oidc-jwt"

--- a/examples/flask_app/app.py
+++ b/examples/flask_app/app.py
@@ -96,6 +96,15 @@ def add_routes(app):
                                "The roles were checked before entering the body of the procedure! "
                                "You provided a valid JWT token")
 
+    @app.route("/api/cookie-secure")
+    @cross_origin(allow_headers=["Content-Type", "Authorization"])
+    @cross_origin(allow_headers=["Access-Control-Allow-Origin", "*"])  # IRL you'd scope this to set domains
+    @jwt.requires_auth_cookie
+    def cookie_secure():
+        """A Cookie is required with JWT to get a response from this endpoint
+        """
+        return jsonify(message="This is a secured endpoint. You provided a valid cookie in request to access.")
+
     return
 
 

--- a/examples/flask_app/config.py
+++ b/examples/flask_app/config.py
@@ -18,6 +18,9 @@ class Config(object):
     JWT_OIDC_AUDIENCE = env.get('JWT_OIDC_AUDIENCE')
     JWT_OIDC_CLIENT_SECRET = env.get('JWT_OIDC_CLIENT_SECRET')
 
+    # JWT_OIDC Cookie settings - Only if application uses cookie for authorization
+    JWT_OIDC_AUTH_COOKIE_NAME = env.get('JWT_OIDC_AUTH_COOKIE_NAME', 'oidc-jwt')
+
     # Flask settings
     DEBUG = False
     TESTING = False

--- a/examples/flask_app/tests/test_flask_app.py
+++ b/examples/flask_app/tests/test_flask_app.py
@@ -125,3 +125,18 @@ def test_current_user_set(app, client, jwt):
     assert rv
     assert _request_ctx_stack.top.current_user.get('username') == claims.get('username')
     assert g.jwt_oidc_token_info.get('username') == claims.get('username')
+
+
+def test_api_cookie_secure(client, jwt):
+    """
+    First test that verifies we have a valid cookie with jwt
+    :fixture client:
+    """
+    token = jwt.create_jwt(claims, token_header)
+    client.set_cookie('/', 'oidc-jwt', token)
+
+    rv = client.get('/api/cookie-secure')
+
+    json_msg = jsonify(message='This is a secured endpoint. You provided a valid cookie in request to access.')
+
+    assert json_msg.data == rv.data

--- a/tests/test_cookie_protected.py
+++ b/tests/test_cookie_protected.py
@@ -1,0 +1,69 @@
+from flask import jsonify
+
+
+def helper_create_jwt(jwt_manager, roles=[]):
+    token_header = {
+        "alg": "RS256",
+        "typ": "JWT",
+        "kid": "flask-jwt-oidc-test-client"
+    }
+    claims = {
+        "iss": "https://example.localdomain/auth/realms/example",
+        "sub": "43e6a245-0bf7-4ccf-9bd0-e7fb85fd18cc",
+        "aud": "example",
+        "exp": 2539722391,
+        "iat": 1539718791,
+        "jti": "flask-jwt-oidc-test-support",
+        "typ": "Bearer",
+        "username": "test-user",
+        "realm_access": {
+            "roles": [] + roles
+        }
+    }
+    return jwt_manager.create_jwt(claims, token_header)
+
+
+def test_protected_requires_auth_cookie_with_no_cookie(client, app, jwt):
+    message = 'This is a cookie protected end-point'
+
+    @app.route('/cookie-protected')
+    @jwt.requires_auth_cookie
+    def get():
+        return jsonify(message=message)
+
+    rv = client.get('/cookie-protected')
+    assert rv.status_code == 401
+
+
+def test_protected_requires_auth_cookie_with_cookie(client, app, jwt):
+    message = 'This is a cookie protected end-point'
+
+    @app.route('/cookie-protected')
+    @jwt.requires_auth_cookie
+    def get():
+        return jsonify(message=message)
+
+    token = helper_create_jwt(jwt)
+    client.set_cookie('/', 'oidc-jwt', token)
+
+    rv = client.get('/cookie-protected')
+    assert message.encode('utf-8') in rv.data
+
+
+def test_protected_requires_auth_cookie_with_custom_cookie_name(client, app, jwt):
+    message = 'This is a cookie protected end-point'
+
+    @app.route('/cookie-protected')
+    @jwt.requires_auth_cookie
+    def get():
+        return jsonify(message=message)
+
+    # Change the name of cookie from default ('oidc-jwt') and validate the token.
+    cookie_name: str = 'custom-jwt-cookie'
+    app.config['JWT_OIDC_AUTH_COOKIE_NAME'] = cookie_name
+
+    token = helper_create_jwt(jwt)
+    client.set_cookie('/', cookie_name, token)
+
+    rv = client.get('/cookie-protected')
+    assert message.encode('utf-8') in rv.data


### PR DESCRIPTION
*Issue #, if available:*
Cannot use the library for cookie auth

*Description of changes:*
- library expects the token as a Bearer token. So for systems which uses cookie for auth won't work well with the library. For e.g, websockets where the token is coming as a cookie. Added a new decorator `requires_auth_cookie` for validating tokens from cookie, with an option to override the cookie name from config `JWT_OIDC_AUTH_COOKIE_NAME`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the flask-jwt-oidc license (Apache 2.0).
