### PR TITLE
Resolve double nesting on JWT_OIDC_ALGORITHMS when using default config

### DIFF
--- a/flask_jwt_oidc/jwt_manager.py
+++ b/flask_jwt_oidc/jwt_manager.py
@@ -32,7 +32,7 @@ from .exceptions import AuthError
 class JwtManager:  # pylint: disable=too-many-instance-attributes
     """Manages the JWT verification and JWKS key lookup."""
 
-    ALGORITHMS = ['RS256']
+    ALGORITHMS = 'RS256'
 
     def __init__(self, app=None):
         """Initialize the JWTManager instance."""
@@ -99,8 +99,9 @@ class JwtManager:  # pylint: disable=too-many-instance-attributes
 
         else:
 
-            self.algorithms = [app.config.get(
-                'JWT_OIDC_ALGORITHMS', JwtManager.ALGORITHMS)]
+            self.algorithms = app.config.get(
+                'JWT_OIDC_ALGORITHMS', JwtManager.ALGORITHMS).replace(' ', '')\
+                .split(',')
 
             # If the WELL_KNOWN_CONFIG is set, then go fetch the JWKS & ISSUER
             self.well_known_config = app.config.get(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If JWT_OIDC_ALGORITHMS is not set in app configuration, it will default to [['RS256']] which is a nested list that causes token decoding to fail due to unsupported algorithm. This change resolves this issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
