### PR TITLE
remove dependency on abanonded python-jose

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ Issues = "https://github.com/thorwolpert/flask-jwt-oidc/issues"
 python = "^3.9"
 Flask = ">=2"
 cachelib = "^0.13.0"
-python-jose = "^3.3.0"
+pyjwt = "^2.8.0"
 six = "^1.16.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This fixes #24 by swapping python-jose for the actively maintained pyjwt.

I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
